### PR TITLE
Reword exception message when running multiple migrations on same con…

### DIFF
--- a/src/TestSuite/Migrator.php
+++ b/src/TestSuite/Migrator.php
@@ -125,7 +125,7 @@ class Migrator
                     "Migrations failed to apply with message:\n\n" .
                     $e->getMessage() . "\n\n" .
                     'If you are using the `skip` option and running multiple sets of migrations ' .
-                    'on the same connection try calling `truncate()` before `runMany()` to avoid this.',
+                    'on the same connection, you can\'t skip tables managed by CakePHP in the connection.',
                     0,
                     $e
                 );


### PR DESCRIPTION
IIUC rewording the exception message is all that's needed here. This is a silly little test PR since I'm new to contributing.

Refs:
- https://github.com/cakephp/migrations/issues/603
